### PR TITLE
fix: align about.ts to golden standard Section 4.9

### DIFF
--- a/src/tools/about.ts
+++ b/src/tools/about.ts
@@ -25,31 +25,41 @@ export function getAbout(db: InstanceType<typeof Database>, context: AboutContex
   const caps = detectCapabilities(db);
   const meta = readDbMetadata(db);
 
+  const euRefs = safeCount(db, 'SELECT COUNT(*) as count FROM eu_references');
+
+  const stats: Record<string, number> = {
+    documents: safeCount(db, 'SELECT COUNT(*) as count FROM legal_documents'),
+    provisions: safeCount(db, 'SELECT COUNT(*) as count FROM legal_provisions'),
+    definitions: safeCount(db, 'SELECT COUNT(*) as count FROM definitions'),
+  };
+
+  if (euRefs > 0) {
+    stats.eu_documents = safeCount(db, 'SELECT COUNT(*) as count FROM eu_documents');
+    stats.eu_references = euRefs;
+  }
+
   return {
-    server: SERVER_NAME,
+    name: 'Portuguese Law MCP',
     version: context.version,
-    repository: REPOSITORY_URL,
-    database: {
-      fingerprint: context.fingerprint,
-      built_at: context.dbBuilt,
-      tier: meta.tier,
-      schema_version: meta.schema_version,
-      capabilities: [...caps],
+    jurisdiction: 'PT',
+    description: 'Portuguese Law MCP — legislation via Model Context Protocol',
+    stats,
+    data_sources: [
+      {
+        name: 'Diario da Republica Eletronico (DRE)',
+        url: 'https://dre.pt',
+        authority: 'Imprensa Nacional-Casa da Moeda',
+      },
+    ],
+    freshness: {
+      database_built: context.dbBuilt,
     },
-    statistics: {
-      documents: safeCount(db, 'SELECT COUNT(*) as count FROM legal_documents'),
-      provisions: safeCount(db, 'SELECT COUNT(*) as count FROM legal_provisions'),
-      definitions: safeCount(db, 'SELECT COUNT(*) as count FROM definitions'),
-      eu_documents: safeCount(db, 'SELECT COUNT(*) as count FROM eu_documents'),
-      eu_references: safeCount(db, 'SELECT COUNT(*) as count FROM eu_references'),
-    },
-    data_source: {
-      name: 'Federal Register of Legislation',
-      authority: 'Portuguese Government, Office of Parliamentary Counsel',
-      url: 'https://www.legislation.gov.au',
-      license: 'Creative Commons Attribution 4.0 International (CC BY 4.0)',
-      jurisdiction: 'AU',
-      languages: ['en'],
+    disclaimer:
+      'This is a research tool, not legal advice. Verify critical citations against official sources.',
+    network: {
+      name: 'Ansvar MCP Network',
+      open_law: 'https://ansvar.eu/open-law',
+      directory: 'https://ansvar.ai/mcp',
     },
   };
 }


### PR DESCRIPTION
## Summary
- Fixes jurisdiction metadata contamination
- Adds disclaimer, freshness, network blocks per golden standard Section 4.9
- Uses data_sources array with correct source name, URL, authority

## Quality checks fixed
- **Q16** — jurisdiction metadata now correct (`PT`)
- **Q25** — disclaimer present
- **Q23** — freshness block present

Generated by `scripts/fleet-fix-about.sh`