### PR TITLE
chore: restore .github/dependabot.yml (Route 2 sweep 2026-04-21)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
Restores the `.github/dependabot.yml` config that was removed from this repo, leaving any open Dependabot PRs unrebaseable (the zombie pattern documented in `Ansvar-Architecture-Documentation/docs/audits/2026-04-21/zombie-dependabot-sweep.md`).

## Why
This repo had 1 zombie Dependabot PRs closed earlier today as part of the Route 2 sweep. Without a `dependabot.yml` Dependabot stays dormant, which long-term is a silent security-scan regression. This PR resumes weekly npm + github-actions scanning with conservative limits.

## Config choices
- **weekly** schedule (not daily) — keeps noise low
- **npm**: max 5 open PRs, **ignores major version bumps** (semver-major) so breaking changes don't auto-open
- **github-actions**: max 3 open PRs
- Minor + patch bumps still open normally — those are the security-relevant ones

## Expected post-merge
- First Dependabot run within 7 days
- Backlog PRs appear gradually (weekly cadence, 5/3 cap)
- Merge burden: ~1-3 PRs/week per repo for a few weeks, then steady state

## Rollback
Revert this PR and the config is gone again. No data loss.

Part of the fleet-wide Route 2 sweep (57 zombies closed + 35 restore PRs). Full report linked above.