### PR TITLE
fix(ci): vitest --passWithNoTests so CI is green on repos without tests yet

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "build:db": "node --import tsx scripts/build-db.ts",
     "dev": "node --import tsx src/index.ts",
     "start": "node dist/index.js",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "census": "node --import tsx scripts/census.ts",


### PR DESCRIPTION
Follows up on [`chore/restore-dependabot-config`](../pull/26) and the 2026-04-21 fleet audit.

This repo's CI runs `npm test` → `vitest run`, which exits with code 1 when no test files match. This repo currently ships no test files, so the first PR in a while (the restore-dependabot PR) exposed the latent failure.

Fix: add `--passWithNoTests` so vitest exits 0 on no-match instead of 1. When real tests are added, they still run and still fail normally on real failures.

Analysis: https://github.com/Ansvar-Systems/Ansvar-Architecture-Documentation/blob/main/docs/audits/2026-04-21/restore-pr-ci-verification.md
Sweep plan: https://github.com/Ansvar-Systems/Ansvar-Architecture-Documentation/blob/main/docs/audits/2026-04-21/b1-passwithnotests-sweep-plan.md