### PR TITLE
chore(license): declare Portuguese-CDADC-Art-7-and-8 (cross-reference Art. 8 + Art. 3(1)(c))

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,8 +372,34 @@ Apache License 2.0. See [LICENSE](./LICENSE) for details.
 
 ### Data Licenses
 
-- **Statutes & Legislation:** Imprensa Nacional - Casa da Moeda (Portuguese open government data)
-- **EU Metadata:** EUR-Lex (EU public domain)
+Ansvar attribution code: **`Portuguese-CDADC-Art-7-and-8`**. Basis:
+**cross-reference** between CDADC (Codigo do Direito de Autor e dos
+Direitos Conexos) Art. 8 and Art. 3(1)(c).
+
+- **Statutes & Legislation:** Imprensa Nacional - Casa da Moeda via
+  Diario da Republica (`dre.pt` / `diariodarepublica.pt`). Reused under
+  CDADC Art. 8 + Art. 3(1)(c).
+- **EU Metadata:** EUR-Lex (EU public-domain notice).
+
+### Coverage scope (cross-reference construction)
+
+Portugal's statutory-PD basis is a **cross-reference** — it requires two
+articles read together:
+
+- **Art. 8 (CDADC):** carves official documents from copyright protection.
+- **Art. 3(1)(c) (CDADC):** defines what counts as an "official document"
+  for the carve-out — legislative acts, administrative regulations,
+  court decisions, and other official texts.
+
+**Why this is NOT Art. 7 alone:** Art. 7 covers only news reports
+(`notícias do dia`), petitions (`petições`), and discourses
+(`discursos`). It does NOT cover statutes. Treating Art. 7 as the
+statutory-PD basis is a common misreading. The correct construction is
+Art. 8 + Art. 3(1)(c).
+
+See `docs/audits/2026-05-17-eu-copyright-statutory-works-batch-2-HU-LU-PT-RO-GR.md`
+in the Ansvar architecture-documentation repo for the verbatim Art. 8
+and Art. 3(1)(c) text and the cross-reference analysis.
 
 ---
 

--- a/sources.yml
+++ b/sources.yml
@@ -13,9 +13,12 @@ sources:
     update_frequency: "daily"
     last_ingested: "PENDING_FIRST_INGEST"
     license_or_terms:
-      type: "Government Open Data (Portuguese Open Data)"
+      type: "Portuguese-CDADC-Art-7-and-8"
+      ansvar_code: "Portuguese-CDADC-Art-7-and-8"
+      statute_ref: "CDADC Art. 8 + Art. 3(1)(c) cross-reference"
       url: "https://dre.pt/termos-de-utilizacao"
-      summary: "DRE is the official electronic journal of the Portuguese Republic, operated by INCM; provides free public access to all legislation published in the Diario da Republica; content is available under Portuguese open data terms for reuse with attribution; structured API available for programmatic access"
+      url_pattern: '^https?://(?:www\.)?diariodarepublica\.pt/.+'
+      summary: "Portuguese statutory-PD carve-out via CDADC (Codigo do Direito de Autor e dos Direitos Conexos) Art. 8 + Art. 3(1)(c) CROSS-REFERENCE. Art. 8 carves official documents from copyright; Art. 3(1)(c) defines the categories. NOT Art. 7 alone — Art. 7 covers only news/petitions/discourses, not statutes. The arch-docs manifest publisher is diariodarepublica.pt (canonical official-gazette mirror of dre.pt). See infrastructure/attribution-licenses.json Portuguese-CDADC-Art-7-and-8."
     coverage:
       scope: "All Portuguese legislation published in the Diario da Republica including Lei 58/2019 (GDPR implementation), Lei 46/2018 (NIS transposition - regime juridico da seguranca do ciberespaco), Codigo das Sociedades Comerciais (CSC), Codigo Penal (cybercrime provisions arts. 193-194, 221), Lei do Comercio Eletronico (DL 7/2004), Lei das Comunicacoes Eletronicas (Lei 16/2022), and Constituicao da Republica Portuguesa"
       limitations: "Some very recent publications may have a short delay before appearing in the API; historical legislation predating digitization may not have fully structured text; consolidated versions of frequently amended laws may lag slightly behind gazette publication"


### PR DESCRIPTION
## Summary

- Sync to verified Ansvar attribution catalog (`Portuguese-CDADC-Art-7-and-8`).
- Basis is a **cross-reference**: CDADC Art. 8 (carves official documents from copyright) read with Art. 3(1)(c) (defines the categories).
- NOT Art. 7 alone — that covers only news/petitions/discourses, not statutes.

## Coverage scope (cross-reference)

- Art. 8 + Art. 3(1)(c) together cover legislative acts, administrative regulations, court decisions, and other official texts.
- README explains why Art. 7 alone is the wrong basis.

## References

- arch-docs audit: `docs/audits/2026-05-17-eu-copyright-statutory-works-batch-2-HU-LU-PT-RO-GR.md`
- arch-docs manifest: `backstage/catalog/fleet-manifests/portuguese-law.json` declares `license: Portuguese-CDADC-Art-7-and-8` with the same cross-reference note.

## Test plan

- [ ] CI passes